### PR TITLE
Update local lax friedrichs for newer jax versions, fixes #2

### DIFF
--- a/hj_reachability/artificial_dissipation.py
+++ b/hj_reachability/artificial_dissipation.py
@@ -23,11 +23,10 @@ def local_lax_friedrichs(partial_max_magnitudes, states, time, values, left_grad
         jnp.maximum(jnp.max(left_grad_values, grid_axes), jnp.max(right_grad_values, grid_axes)))
     local_local_grad_value_boxes = sets.Box(jnp.minimum(left_grad_values, right_grad_values),
                                             jnp.maximum(left_grad_values, right_grad_values))
-    local_grad_value_boxes = jax.tree_multimap(
-        lambda global_grad_value, local_local_grad_values: jax.ops.index_update(
-            jnp.broadcast_to(global_grad_value, values.shape +
-                             (values.ndim,) * 2), jax.ops.index[..., grid_axes, grid_axes], local_local_grad_values),
-        global_grad_value_box, local_local_grad_value_boxes)
+    local_grad_value_boxes = jax.tree_util.tree_map(
+        lambda global_grad_value, local_local_grad_values: jnp.broadcast_to(
+            global_grad_value, values.shape + (values.ndim,) * 2).at[jnp.index_exp[..., grid_axes, grid_axes]].set(local_local_grad_values), global_grad_value_box, local_local_grad_value_boxes
+    )
     return utils.multivmap(
         lambda state, value, grad_value_box: partial_max_magnitudes(state, time, value, grad_value_box),
         grid_axes)(states, values, local_grad_value_boxes)


### PR DESCRIPTION
- [x] update code to work with newer jax versions, fixes #2  . Some of the used jax methods are depreceated and have been removed. `jax.tree_util.tree_multimap` has been removed since [jax 0.3.16](https://jax.readthedocs.io/en/latest/changelog.html#jax-0-3-16), `jax.ops.index_update` and `jax.ops.index` ave been removed since [jax 0.3.2](https://jax.readthedocs.io/en/latest/changelog.html#jax-0-3-16). Tested with `jax==0.3.23` and `jax_lib==0.3.22`.
- [ ] Specify Jax version in requirements.